### PR TITLE
Fix CRAN issue "lost braces"

### DIFF
--- a/R/bp_report.R
+++ b/R/bp_report.R
@@ -8,17 +8,17 @@
 #' the following variables must be present and properly formatted:
 #' \itemize{
 #'
-#' \item{\code{SBP}}
-#' \item{\code{DBP}}
-#' \item{\code{DATE_TIME}} - Used in the \code{process_data} function to create additional columns
+#' \item \code{SBP}
+#' \item \code{DBP}
+#' \item \code{DATE_TIME} - Used in the \code{process_data} function to create additional columns
 #' that are needed for the \code{bp_report} function (SBP_Category, DBP_Category, Weekday, and
 #' Time_of_Day.)
-#' \item{\code{SBP_CATEGORY}} - Automatically calculated in the \code{process_data} function
-#' \item{\code{DBP_CATEGORY}} - Automatically calculated in the \code{process_data} function
-#' \item{\code{DAY_OF_WEEK}} - Automatically calculated in the \code{process_data} function
-#' \item{\code{TIME_OF_DAY}} - Automatically calculated in the \code{process_data} function
-#' \item{\code{ID}} - (If applicable) Used for separating out different individuals, if more than one
-#' \item{\code{VISIT}} - (If applicable) Used for separating out an individuals' different visits,
+#' \item \code{SBP_CATEGORY} - Automatically calculated in the \code{process_data} function
+#' \item \code{DBP_CATEGORY} - Automatically calculated in the \code{process_data} function
+#' \item \code{DAY_OF_WEEK} - Automatically calculated in the \code{process_data} function
+#' \item \code{TIME_OF_DAY} - Automatically calculated in the \code{process_data} function
+#' \item \code{ID} - (If applicable) Used for separating out different individuals, if more than one
+#' \item \code{VISIT} - (If applicable) Used for separating out an individuals' different visits,
 #' if more than one
 #'
 #' }
@@ -62,13 +62,13 @@
 #' Although PDF is the default possible options include:
 #' \itemize{
 #'
-#' \item{pdf} (default)
-#' \item{png}
-#' \item{jpeg}
-#' \item{tiff}
-#' \item{bmp}
-#' \item{eps}
-#' \item{ps}
+#' \item pdf (default)
+#' \item png
+#' \item jpeg
+#' \item tiff
+#' \item bmp
+#' \item eps
+#' \item ps
 #'
 #' }
 #'

--- a/R/bp_report.R
+++ b/R/bp_report.R
@@ -78,11 +78,11 @@
 #'
 #' @param scale A multiplicative scaling factor for the report output.
 #'
-#' @param plot A logical value indicating whether to automatically produce the plot of bp_report, or suppress the output. The default value is TRUE. If false, the returned object is a grob that can be plotted using \code{\link{grid.arrange}}
+#' @param plot A logical value indicating whether to automatically produce the plot of bp_report, or suppress the output. The default value is TRUE. If false, the returned object is a grob that can be plotted using \code{\link[gridExtra]{grid.arrange}}
 #'
 #' @param hist_bins An integer specifying how many bins to use for histogram plots. This is a ggplot parameter; default value set to 30
 #'
-#' @return If \code{plot = TRUE}, the function produces a plot of BP report that contains scatterplot of BP values by stages (see \code{\link{bp_scatter}}), histograms of BP values by stages (see \code{\link{bp_hist}}) and frequency tables of BP values by stages and day of the week/time of the day (see \code{\link{dow_tod_plots}}). If \code{plot = FALSE}, the function returns the grob object that can be plotted later using \code{\link{grid.arrange}}. If \code{save_report = TRUE}, the report will be automatically saved at the current working directory (can be checked using \code{getwd()}) or at specified file path.
+#' @return If \code{plot = TRUE}, the function produces a plot of BP report that contains scatterplot of BP values by stages (see \code{\link{bp_scatter}}), histograms of BP values by stages (see \code{\link{bp_hist}}) and frequency tables of BP values by stages and day of the week/time of the day (see \code{\link{dow_tod_plots}}). If \code{plot = FALSE}, the function returns the grob object that can be plotted later using \code{\link[gridExtra]{grid.arrange}}. If \code{save_report = TRUE}, the report will be automatically saved at the current working directory (can be checked using \code{getwd()}) or at specified file path.
 #'
 #' @export
 #'

--- a/R/bp_stages.R
+++ b/R/bp_stages.R
@@ -193,7 +193,7 @@ If this is a mistake, leave bp_cutoffs to default values and keep guidelines = "
 #'
 #' @references
 #' Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, et al. Cardiovascular risk of isolated systolic
-#' or diastolic hypertension in young adults. \emph{Circulation}. 2020;141(22):1778–1786.
+#' or diastolic hypertension in young adults. \emph{Circulation}. 2020;141(22):1778-1786.
 #' \doi{0.1161/CIRCULATIONAHA.119.044838}
 #'
 #' Muntner, P., Carey, R. M., Jamerson, K., Wright Jr, J. T., & Whelton, P. K. (2019). Rationale for ambulatory and home blood pressure monitoring thresholds in the 2017 American College of Cardiology/American Heart Association Guideline. Hypertension, 73(1), 33-38.

--- a/R/bp_sv.R
+++ b/R/bp_sv.R
@@ -7,11 +7,11 @@
 #' temporal structure of the data and relies on the sum of squared differences
 #' in successive observations, unlike the average real variability (ARV)
 #' which relies on the sum of absolute differences.
-#' $$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+#' \deqn{SV = \sqrt{\frac{\sum(x_{i+1} - x_i)^2}{n-1}}}
 #'
 #' \strong{NOTE:} The canonical standard deviation, independent of the temporal
 #' structure using the sample average, is added for comparison:
-#' $$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+#' \deqn{SD = \sqrt{\frac{\sum(x_{i+1} - \bar{x})^2}{n-1}}}
 #'
 #' @param data Required argument. Pre-processed dataframe with SBP and DBP columns
 #' with optional ID, VISIT, WAKE, and DATE columns if available.

--- a/R/bp_visuals_scatter.R
+++ b/R/bp_visuals_scatter.R
@@ -96,7 +96,7 @@
 #'
 #' @references
 #' Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, Kim HC. Cardiovascular risk of isolated
-#' systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778–1786.
+#' systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778-1786.
 #' \doi{10.1161/CIRCULATIONAHA.119.044838}
 #'
 #' Unger, T., Borghi, C., Charchar, F., Khan, N. A., Poulter, N. R., Prabhakaran, D., ... & Schutte,

--- a/R/data.R
+++ b/R/data.R
@@ -308,7 +308,7 @@
 #' salt-sensitive Dahl rats on Hypertension.
 #'
 #' (Goldberger A., Amaral L., Glass L., Hausdorff J., Ivanov P. C., Mark R., Bugenhagen S.M.,
-#' Cowley A.W. Jr, Beard D.A., ... \& Stanley H. E. 2000).
+#' Cowley A.W. Jr, Beard D.A., ... & Stanley H. E. 2000).
 #'
 #' Licensed under a ODC-BY (Creative Commons) Open Data Commons Attribution License 1.0
 #'

--- a/R/data_process.R
+++ b/R/data_process.R
@@ -201,7 +201,7 @@
 #'
 #' @references
 #' Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, Kim HC. Cardiovascular risk of isolated
-#' systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778–1786.
+#' systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778-1786.
 #' \doi{10.1161/CIRCULATIONAHA.119.044838}
 #'
 #' Muntner, P., Carey, R. M., Jamerson, K., Wright Jr, J. T., & Whelton, P. K. (2019). Rationale for ambulatory and home blood pressure monitoring thresholds in the 2017 American College of Cardiology/American Heart Association Guideline. Hypertension, 73(1), 33-38. \doi{10.1161/HYPERTENSIONAHA.118.11946}

--- a/R/dip_calc.R
+++ b/R/dip_calc.R
@@ -76,10 +76,10 @@
 #' default dipping threshold of 10\% and extreme dipping threshold of 20\% according to the original source):
 #'
 #' \itemize{
-#'    \item{Reverse Dipper - no nocturnal decline (greater or equal to 0\%)}
-#'    \item{Non-Dipper - a nocturnal decline between 0 - 10\%}
-#'    \item{Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)}
-#'    \item{Extreme Dipper - a nocturnal decline exceeding 20\%}
+#'    \item Reverse Dipper - no nocturnal decline (greater or equal to 0\%)
+#'    \item Non-Dipper - a nocturnal decline between 0 - 10\%
+#'    \item Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)
+#'    \item Extreme Dipper - a nocturnal decline exceeding 20\%
 #' }
 #'
 #' @export

--- a/R/dip_class_plot.R
+++ b/R/dip_class_plot.R
@@ -59,10 +59,10 @@
 #'
 #' The default plot categories are as follows:
 #' \itemize{
-#'    \item{\emph{INV}: Inverted (Reverse) Dipper - no nocturnal decline (greater or equal to 0\%)}
-#'    \item{\emph{ND}: Non-Dipper - a nocturnal decline between 0 - 10\%}
-#'    \item{\emph{DIP}: Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)}
-#'    \item{\emph{ED}: Extreme Dipper - a nocturnal decline exceeding 20\%}
+#'    \item \emph{INV}: Inverted (Reverse) Dipper - no nocturnal decline (greater or equal to 0\%)
+#'    \item \emph{ND}: Non-Dipper - a nocturnal decline between 0 - 10\%
+#'    \item \emph{DIP}: Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)
+#'    \item \emph{ED}: Extreme Dipper - a nocturnal decline exceeding 20\%
 #' }
 #'
 #' @export

--- a/R/sv.R
+++ b/R/sv.R
@@ -9,11 +9,11 @@
 #' temporal structure of the data and relies on the sum of squared differences
 #' in successive observations, unlike the average real variability (ARV)
 #' which relies on the sum of absolute differences.
-#' $$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+#' \deqn{SV = \sqrt{\frac{\sum(x_{i+1} - x_i)^2}{n-1}}}
 #'
 #' \strong{NOTE:} The canonical standard deviation, independent of the temporal
 #' structure using the sample average, is added for comparison:
-#' $$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+#' \deqn{SD = \sqrt{\frac{\sum(x_{i+1} - \bar{x})^2}{n-1}}}
 #'
 #' @param data Required argument. Pre-processed dataframe with SBP and DBP columns
 #' with optional ID, VISIT, WAKE, and DATE columns if available.

--- a/man/bp_rats.Rd
+++ b/man/bp_rats.Rd
@@ -38,7 +38,7 @@ salt-sensitive Dahl rats on Hypertension.
 }
 \details{
 (Goldberger A., Amaral L., Glass L., Hausdorff J., Ivanov P. C., Mark R., Bugenhagen S.M.,
-Cowley A.W. Jr, Beard D.A., ... \& Stanley H. E. 2000).
+Cowley A.W. Jr, Beard D.A., ... & Stanley H. E. 2000).
 
 Licensed under a ODC-BY (Creative Commons) Open Data Commons Attribution License 1.0
 }

--- a/man/bp_report.Rd
+++ b/man/bp_report.Rd
@@ -98,12 +98,12 @@ millimeters ("mm") are also available.}
 
 \item{scale}{A multiplicative scaling factor for the report output.}
 
-\item{plot}{A logical value indicating whether to automatically produce the plot of bp_report, or suppress the output. The default value is TRUE. If false, the returned object is a grob that can be plotted using \code{\link{grid.arrange}}}
+\item{plot}{A logical value indicating whether to automatically produce the plot of bp_report, or suppress the output. The default value is TRUE. If false, the returned object is a grob that can be plotted using \code{\link[gridExtra]{grid.arrange}}}
 
 \item{hist_bins}{An integer specifying how many bins to use for histogram plots. This is a ggplot parameter; default value set to 30}
 }
 \value{
-If \code{plot = TRUE}, the function produces a plot of BP report that contains scatterplot of BP values by stages (see \code{\link{bp_scatter}}), histograms of BP values by stages (see \code{\link{bp_hist}}) and frequency tables of BP values by stages and day of the week/time of the day (see \code{\link{dow_tod_plots}}). If \code{plot = FALSE}, the function returns the grob object that can be plotted later using \code{\link{grid.arrange}}. If \code{save_report = TRUE}, the report will be automatically saved at the current working directory (can be checked using \code{getwd()}) or at specified file path.
+If \code{plot = TRUE}, the function produces a plot of BP report that contains scatterplot of BP values by stages (see \code{\link{bp_scatter}}), histograms of BP values by stages (see \code{\link{bp_hist}}) and frequency tables of BP values by stages and day of the week/time of the day (see \code{\link{dow_tod_plots}}). If \code{plot = FALSE}, the function returns the grob object that can be plotted later using \code{\link[gridExtra]{grid.arrange}}. If \code{save_report = TRUE}, the report will be automatically saved at the current working directory (can be checked using \code{getwd()}) or at specified file path.
 }
 \description{
 The \code{bp_report} function serves to aggregate various data visuals and metrics

--- a/man/bp_report.Rd
+++ b/man/bp_report.Rd
@@ -28,17 +28,17 @@ function to properly format data set. In order for the \code{bp_report} function
 the following variables must be present and properly formatted:
 \itemize{
 
-\item{\code{SBP}}
-\item{\code{DBP}}
-\item{\code{DATE_TIME}} - Used in the \code{process_data} function to create additional columns
+\item \code{SBP}
+\item \code{DBP}
+\item \code{DATE_TIME} - Used in the \code{process_data} function to create additional columns
 that are needed for the \code{bp_report} function (SBP_Category, DBP_Category, Weekday, and
 Time_of_Day.)
-\item{\code{SBP_CATEGORY}} - Automatically calculated in the \code{process_data} function
-\item{\code{DBP_CATEGORY}} - Automatically calculated in the \code{process_data} function
-\item{\code{DAY_OF_WEEK}} - Automatically calculated in the \code{process_data} function
-\item{\code{TIME_OF_DAY}} - Automatically calculated in the \code{process_data} function
-\item{\code{ID}} - (If applicable) Used for separating out different individuals, if more than one
-\item{\code{VISIT}} - (If applicable) Used for separating out an individuals' different visits,
+\item \code{SBP_CATEGORY} - Automatically calculated in the \code{process_data} function
+\item \code{DBP_CATEGORY} - Automatically calculated in the \code{process_data} function
+\item \code{DAY_OF_WEEK} - Automatically calculated in the \code{process_data} function
+\item \code{TIME_OF_DAY} - Automatically calculated in the \code{process_data} function
+\item \code{ID} - (If applicable) Used for separating out different individuals, if more than one
+\item \code{VISIT} - (If applicable) Used for separating out an individuals' different visits,
 if more than one
 
 }}
@@ -82,13 +82,13 @@ The default is set to 8.53 inches.}
 Although PDF is the default possible options include:
 \itemize{
 
-\item{pdf} (default)
-\item{png}
-\item{jpeg}
-\item{tiff}
-\item{bmp}
-\item{eps}
-\item{ps}
+\item pdf (default)
+\item png
+\item jpeg
+\item tiff
+\item bmp
+\item eps
+\item ps
 
 }}
 

--- a/man/bp_scatter.Rd
+++ b/man/bp_scatter.Rd
@@ -191,7 +191,7 @@ bp_scatter(bp::bp_ghana, inc_crisis = TRUE, inc_low = FALSE, group_var = "TIME_E
 }
 \references{
 Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, Kim HC. Cardiovascular risk of isolated
-systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778–1786.
+systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778-1786.
 \doi{10.1161/CIRCULATIONAHA.119.044838}
 
 Unger, T., Borghi, C., Charchar, F., Khan, N. A., Poulter, N. R., Prabhakaran, D., ... & Schutte,

--- a/man/bp_stages.Rd
+++ b/man/bp_stages.Rd
@@ -135,7 +135,7 @@ bp_stages(bp_jhs, sbp = "sys.mmhg.", dbp = "dias.mmhg.")
 }
 \references{
 Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, et al. Cardiovascular risk of isolated systolic
-or diastolic hypertension in young adults. \emph{Circulation}. 2020;141(22):1778–1786.
+or diastolic hypertension in young adults. \emph{Circulation}. 2020;141(22):1778-1786.
 \doi{0.1161/CIRCULATIONAHA.119.044838}
 
 Muntner, P., Carey, R. M., Jamerson, K., Wright Jr, J. T., & Whelton, P. K. (2019). Rationale for ambulatory and home blood pressure monitoring thresholds in the 2017 American College of Cardiology/American Heart Association Guideline. Hypertension, 73(1), 33-38.

--- a/man/bp_sv.Rd
+++ b/man/bp_sv.Rd
@@ -72,12 +72,12 @@ DBP, or both. SV is a measure of dispersion that takes into account the
 temporal structure of the data and relies on the sum of squared differences
 in successive observations, unlike the average real variability (ARV)
 which relies on the sum of absolute differences.
-$$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+\deqn{SV = \sqrt{\frac{\sum(x_{i+1} - x_i)^2}{n-1}}}
 }
 \details{
 \strong{NOTE:} The canonical standard deviation, independent of the temporal
 structure using the sample average, is added for comparison:
-$$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+\deqn{SD = \sqrt{\frac{\sum(x_{i+1} - \bar{x})^2}{n-1}}}
 }
 \examples{
 # Load data

--- a/man/dip_calc.Rd
+++ b/man/dip_calc.Rd
@@ -61,10 +61,10 @@ tibbles will be broken down further by date. There are 4 classifications a subje
 default dipping threshold of 10\% and extreme dipping threshold of 20\% according to the original source):
 
 \itemize{
-   \item{Reverse Dipper - no nocturnal decline (greater or equal to 0\%)}
-   \item{Non-Dipper - a nocturnal decline between 0 - 10\%}
-   \item{Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)}
-   \item{Extreme Dipper - a nocturnal decline exceeding 20\%}
+   \item Reverse Dipper - no nocturnal decline (greater or equal to 0\%)
+   \item Non-Dipper - a nocturnal decline between 0 - 10\%
+   \item Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)
+   \item Extreme Dipper - a nocturnal decline exceeding 20\%
 }
 }
 \description{

--- a/man/dip_class_plot.Rd
+++ b/man/dip_class_plot.Rd
@@ -51,10 +51,10 @@ dipping categories. Any dips below zero are denoted as Inverted (or Reverse) dip
 
 The default plot categories are as follows:
 \itemize{
-   \item{\emph{INV}: Inverted (Reverse) Dipper - no nocturnal decline (greater or equal to 0\%)}
-   \item{\emph{ND}: Non-Dipper - a nocturnal decline between 0 - 10\%}
-   \item{\emph{DIP}: Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)}
-   \item{\emph{ED}: Extreme Dipper - a nocturnal decline exceeding 20\%}
+   \item \emph{INV}: Inverted (Reverse) Dipper - no nocturnal decline (greater or equal to 0\%)
+   \item \emph{ND}: Non-Dipper - a nocturnal decline between 0 - 10\%
+   \item \emph{DIP}: Dipper - a nocturnal decline between 10\% and the extreme dipping \% (20\%)
+   \item \emph{ED}: Extreme Dipper - a nocturnal decline exceeding 20\%
 }
 }
 \description{

--- a/man/process_data.Rd
+++ b/man/process_data.Rd
@@ -282,7 +282,7 @@ jhs_proc
 }
 \references{
 Lee H, Yano Y, Cho SMJ, Park JH, Park S, Lloyd-Jones DM, Kim HC. Cardiovascular risk of isolated
-systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778–1786.
+systolic or diastolic hypertension in young adults. \emph{Circulation}. 2020; 141:1778-1786.
 \doi{10.1161/CIRCULATIONAHA.119.044838}
 
 Muntner, P., Carey, R. M., Jamerson, K., Wright Jr, J. T., & Whelton, P. K. (2019). Rationale for ambulatory and home blood pressure monitoring thresholds in the 2017 American College of Cardiology/American Heart Association Guideline. Hypertension, 73(1), 33-38. \doi{10.1161/HYPERTENSIONAHA.118.11946}

--- a/man/sv.Rd
+++ b/man/sv.Rd
@@ -75,11 +75,11 @@ DBP, or both. SV is a measure of dispersion that takes into account the
 temporal structure of the data and relies on the sum of squared differences
 in successive observations, unlike the average real variability (ARV)
 which relies on the sum of absolute differences.
-$$SV = sqrt(sum(x_{i+1} - x_i)^2/n-1)$$
+\deqn{SV = \sqrt{\frac{\sum(x_{i+1} - x_i)^2}{n-1}}}
 
 \strong{NOTE:} The canonical standard deviation, independent of the temporal
 structure using the sample average, is added for comparison:
-$$SD = sqrt(sum(x_{i+1} - xbar)^2/n-1)$$
+\deqn{SD = \sqrt{\frac{\sum(x_{i+1} - \bar{x})^2}{n-1}}}
 }
 \examples{
 # Load data


### PR DESCRIPTION
This pull request implements a fix for the "Lost braces" issues detected in the package documentation (.Rd files) by R CMD check and flagged by CRAN (see <https://cran.r-project.org/web/checks/check_results_bp.html>)

## Summary of changes

- Fix "Lost braces" documentation error (this was the primary objective of the R Dev Day task)
- I spotted other documentation errors with `tools:checkRd` and also fixed these:
    - "Non-ASCII contents without declared encoding" (added UTF-8 encoding to cover the page range dash)
    - incorrectly defined mathematical equations in `bp_sv.Rd` and `sv.Rd`
- There was also a CRAN check error "Please provide package anchors for all Rd \link{} targets not in the package itself and the base packages" which I have fixed in `bp_report.Rd`

## Context

This task was proposed by R Core developer Kurt Hornik as part of an initiative to improve CRAN package documentation. Packages with public repositories (GitHub, GitLab, Bitbucket) and a higher number of reverse dependencies were prioritised. This PR has been completed as part of an R Dev Day at the University of Warwick on 12 Sept 2025 (see https://github.com/r-devel/r-dev-day/issues/110).

## Suggested next steps

- Merge this PR to incorporate the fixes.
- Monitor subsequent CRAN checks to confirm the NOTE does not reappear.
- The following can be used to identify the issues with the documentation which initially triggered inclusion in the Dev Day task: `list.files("man", full.names = TRUE) |> sapply(tools::checkRd)`.
